### PR TITLE
Corregir ejemplo de norma 1 en teoria-2.tex

### DIFF
--- a/2-guia/teoria-2/teoria-2.tex
+++ b/2-guia/teoria-2/teoria-2.tex
@@ -104,11 +104,11 @@
                   \draw[blue, thick] (0,0) circle (1);
                 \end{tikzpicture}
 
-          \item Norma $p$:
-                $\norma{x}_p = \sqrt{\sumatoria{k=0}{n} |x_k|^p }
+          \item Norma $1$:
+                $\norma{x}_1 = \sqrt{\sumatoria{k=0}{n} |x_k|^1 }
                   \quad
                   \flecha{por ejemplo}
-                  \norma{x}_p = 1 \quad$
+                  \norma{x}_1 = 1 \quad$
                 \begin{tikzpicture}[plot settings, add axes]
                   \draw[red, thick] (0,1) -- (1,0) -- (0,-1) -- (-1,0) -- cycle;
                 \end{tikzpicture}


### PR DESCRIPTION
El grafico del rombo corresponde unicamente a la norma 1, no cualquier norma p.